### PR TITLE
UI usability tweaks

### DIFF
--- a/lib/deposit.dart
+++ b/lib/deposit.dart
@@ -199,7 +199,6 @@ class _CryptoDepositsScreenState extends State<CryptoDepositsScreen> {
     var res = await beCryptoDepositRecipient(
         widget.asset.symbol, widget.l2Network?.symbol, amount);
     Navigator.pop(context);
-    Navigator.pop(context);
     res.when(
         (recipient, asset, l2Network) => Navigator.push(
             context,

--- a/lib/deposit.dart
+++ b/lib/deposit.dart
@@ -552,9 +552,11 @@ class _FiatDepositsScreenState extends State<FiatDepositsScreen> {
                     builder: (context) =>
                         FiatDepositDetailScreen(deposit, widget.websocket)));
             success = true;
-          },
-              error: (err) => alert(context, 'error',
-                  'failed to create deposit (${BeError.msg(err)})'));
+          }, error: (err) async {
+            var msg = BeError.msg(err);
+            snackMsg(context, 'failed to create deposit: ${msg}',
+                category: MessageCategory.Warning);
+          });
         }
         ;
         break;

--- a/lib/deposit.dart
+++ b/lib/deposit.dart
@@ -199,6 +199,7 @@ class _CryptoDepositsScreenState extends State<CryptoDepositsScreen> {
     var res = await beCryptoDepositRecipient(
         widget.asset.symbol, widget.l2Network?.symbol, amount);
     Navigator.pop(context);
+    Navigator.pop(context);
     res.when(
         (recipient, asset, l2Network) => Navigator.push(
             context,

--- a/lib/event.dart
+++ b/lib/event.dart
@@ -31,7 +31,6 @@ class _DepositReceivedScreenState extends State<DepositReceivedScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
         appBar: AppBar(
-          automaticallyImplyLeading: false,
           title: Text('Deposit Received'),
           actions: [
             assetLogo(

--- a/lib/event.dart
+++ b/lib/event.dart
@@ -6,6 +6,7 @@ import 'package:zapdart/colors.dart';
 import 'assets.dart';
 import 'widgets.dart';
 import 'config.dart';
+import 'main.dart';
 
 class DepositReceivedScreen extends StatefulWidget {
   final String asset;
@@ -65,9 +66,17 @@ class _DepositReceivedScreenState extends State<DepositReceivedScreen> {
                               : SizedBox()
                         ])),
                   ),
-                  BronzeRoundedButton(() => Navigator.of(context).pop(),
-                      Colors.white, Colors.white30, null, 'Close',
-                      width: ButtonWidth, height: ButtonHeight)
+                  BronzeRoundedButton(
+                      () => Navigator.of(context).pushAndRemoveUntil(
+                          MaterialPageRoute(
+                              builder: (c) => MyHomePage(title: AppTitle)),
+                          (route) => false),
+                      Colors.white,
+                      Colors.white30,
+                      null,
+                      'Close',
+                      width: ButtonWidth,
+                      height: ButtonHeight)
                 ]))));
   }
 }

--- a/lib/event.dart
+++ b/lib/event.dart
@@ -102,7 +102,6 @@ class _DepositAmountScreenState extends State<DepositAmountScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
         appBar: AppBar(
-          automaticallyImplyLeading: false,
           title: Text('Deposit'),
           actions: [
             assetLogo(
@@ -131,8 +130,7 @@ class _DepositAmountScreenState extends State<DepositAmountScreen> {
                                 BronzeValueInput(
                                   controller: _amountController,
                                   suffixText: '${assetUnit(widget.asset)}',
-                                  labelText:
-                                      'Amount (${assetUnit(widget.asset)})',
+                                  labelText: 'Amount',
                                   validator: (value) {
                                     if (value == null || value.isEmpty)
                                       return 'Please enter a value';
@@ -264,6 +262,9 @@ class _DepositMethodScreenState extends State<DepositMethodScreen> {
                           shrinkWrap: true,
                           itemCount: widget.methods.length,
                           itemBuilder: _buildMethod)),
+                  BronzeRoundedButton(() => Navigator.of(context).pop(),
+                      Colors.white, Colors.white30, null, 'Cancel',
+                      width: ButtonWidth, height: ButtonHeight)
                 ]))));
   }
 }

--- a/lib/event.dart
+++ b/lib/event.dart
@@ -6,7 +6,6 @@ import 'package:zapdart/colors.dart';
 import 'assets.dart';
 import 'widgets.dart';
 import 'config.dart';
-import 'main.dart';
 
 class DepositReceivedScreen extends StatefulWidget {
   final String asset;
@@ -66,17 +65,9 @@ class _DepositReceivedScreenState extends State<DepositReceivedScreen> {
                               : SizedBox()
                         ])),
                   ),
-                  BronzeRoundedButton(
-                      () => Navigator.of(context).pushAndRemoveUntil(
-                          MaterialPageRoute(
-                              builder: (c) => MyHomePage(title: AppTitle)),
-                          (route) => false),
-                      Colors.white,
-                      Colors.white30,
-                      null,
-                      'Close',
-                      width: ButtonWidth,
-                      height: ButtonHeight)
+                  BronzeRoundedButton(() => Navigator.of(context).pop(),
+                      Colors.white, Colors.white30, null, 'Close',
+                      width: ButtonWidth, height: ButtonHeight)
                 ]))));
   }
 }

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -42,12 +42,14 @@ class BronzeFormInput extends StatelessWidget {
   final bool? obscureText;
   final Icon? icon;
   final Widget? suffixIcon;
+  final String? suffixText;
   BronzeFormInput(this.controller,
       {this.validator,
       this.keyboardType,
       this.obscureText,
       this.labelText,
       this.suffixIcon,
+      this.suffixText,
       this.icon})
       : super();
 
@@ -68,6 +70,7 @@ class BronzeFormInput extends StatelessWidget {
           filled: true,
           floatingLabelBehavior: FloatingLabelBehavior.never,
           labelText: this.labelText ?? null,
+          suffixText: this.suffixText,
           constraints: BoxConstraints(
               minWidth: cfg.ButtonWidth, maxWidth: cfg.ButtonWidth),
           border: OutlineInputBorder(

--- a/lib/withdrawal.dart
+++ b/lib/withdrawal.dart
@@ -82,9 +82,7 @@ class _WithdrawalCheckScreenState extends State<WithdrawalCheckScreen> {
                         subtitle: Text(
                             '${assetFormatWithUnitToUser(widget.asset.symbol, widget.amount != null ? widget.amount! : _extractedAmount)}')),
                     ListTile(
-                        title: widget.l2Network != null
-                            ? Text('Invoice')
-                            : Text('Recipient'),
+                        title: Text('Recipient'),
                         subtitle: Text(shortenStr(widget.recipient)))
                   ]),
                   Column(
@@ -369,7 +367,7 @@ class _WithdrawalFormScreenState extends State<WithdrawalFormScreen> {
                         widget.asset.isCrypto && widget.l2Network != null,
                         BronzeFormInput(_recipientController,
                             icon: Icon(Icons.person_outlined),
-                            labelText: 'Invoice',
+                            labelText: 'Recipient',
                             suffixIcon: IconButton(
                                 onPressed: _scanRecipient,
                                 icon: Icon(Icons.qr_code)),

--- a/lib/withdrawal.dart
+++ b/lib/withdrawal.dart
@@ -180,6 +180,7 @@ class _WithdrawalFormScreenState extends State<WithdrawalFormScreen> {
   }
 
   void _withdrawalCreate() async {
+    bool? didError;
     if (_formKey.currentState == null) return;
     if (_formKey.currentState!.validate()) {
       // ask user to confirm
@@ -223,15 +224,16 @@ class _WithdrawalFormScreenState extends State<WithdrawalFormScreen> {
             _recipientDescriptionController.text,
             tfCode);
         Navigator.pop(context);
-        Navigator.pop(context);
         res.when(
             (withdrawal) => Navigator.push(
                 context,
                 MaterialPageRoute(
                     builder: (context) => CryptoWithdrawalDetailScreen(
-                        withdrawal, widget.websocket))),
-            error: (err) => alert(context, 'error',
-                'failed to create withdrawal (${BeError.msg(err)})'));
+                        withdrawal, widget.websocket))), error: (err) {
+          didError = true;
+          return alert(context, 'error',
+              'failed to create withdrawal (${BeError.msg(err)})');
+        });
       } else {
         showAlertDialog(context, 'creating withdrawal..');
         var res = await beFiatWithdrawalCreate(
@@ -250,9 +252,15 @@ class _WithdrawalFormScreenState extends State<WithdrawalFormScreen> {
                 context,
                 MaterialPageRoute(
                     builder: (context) => FiatWithdrawalDetailScreen(
-                        withdrawal, widget.websocket))),
-            error: (err) => alert(context, 'error',
-                'failed to create withdrawal (${BeError.msg(err)})'));
+                        withdrawal, widget.websocket))), error: (err) {
+          didError = true;
+          return alert(context, 'error',
+              'failed to create withdrawal (${BeError.msg(err)})');
+        });
+      }
+      if (didError == null) {
+        Navigator.pop(context);
+        Navigator.pop(context);
       }
     }
   }

--- a/lib/withdrawal.dart
+++ b/lib/withdrawal.dart
@@ -320,8 +320,8 @@ class _WithdrawalFormScreenState extends State<WithdrawalFormScreen> {
                               icon: widget.asset.isCrypto
                                   ? Icon(Icons.currency_bitcoin)
                                   : Icon(Icons.attach_money),
-                              labelText:
-                                  'Amount (${assetUnit(widget.asset.symbol)})',
+                              labelText: 'Amount',
+                              suffixText: assetUnit(widget.asset.symbol),
                               suffixIcon: TextButton(
                                   child: Text('max',
                                       style: TextStyle(color: ZapOnPrimary)),

--- a/lib/withdrawal.dart
+++ b/lib/withdrawal.dart
@@ -180,7 +180,6 @@ class _WithdrawalFormScreenState extends State<WithdrawalFormScreen> {
   }
 
   void _withdrawalCreate() async {
-    bool? didError;
     if (_formKey.currentState == null) return;
     if (_formKey.currentState!.validate()) {
       // ask user to confirm
@@ -224,16 +223,16 @@ class _WithdrawalFormScreenState extends State<WithdrawalFormScreen> {
             _recipientDescriptionController.text,
             tfCode);
         Navigator.pop(context);
-        res.when(
-            (withdrawal) => Navigator.push(
-                context,
-                MaterialPageRoute(
-                    builder: (context) => CryptoWithdrawalDetailScreen(
-                        withdrawal, widget.websocket))), error: (err) {
-          didError = true;
-          return alert(context, 'error',
-              'failed to create withdrawal (${BeError.msg(err)})');
-        });
+        res.when((withdrawal) async {
+          await Navigator.push(
+              context,
+              MaterialPageRoute(
+                  builder: (context) => CryptoWithdrawalDetailScreen(
+                      withdrawal, widget.websocket)));
+          Navigator.pop(context);
+        },
+            error: (err) => alert(context, 'error',
+                'failed to create withdrawal (${BeError.msg(err)})'));
       } else {
         showAlertDialog(context, 'creating withdrawal..');
         var res = await beFiatWithdrawalCreate(
@@ -247,20 +246,16 @@ class _WithdrawalFormScreenState extends State<WithdrawalFormScreen> {
             _accountAddrCountryController.text,
             tfCode);
         Navigator.pop(context);
-        res.when(
-            (withdrawal) => Navigator.push(
-                context,
-                MaterialPageRoute(
-                    builder: (context) => FiatWithdrawalDetailScreen(
-                        withdrawal, widget.websocket))), error: (err) {
-          didError = true;
-          return alert(context, 'error',
-              'failed to create withdrawal (${BeError.msg(err)})');
-        });
-      }
-      if (didError == null) {
-        Navigator.pop(context);
-        Navigator.pop(context);
+        res.when((withdrawal) async {
+          await Navigator.push(
+              context,
+              MaterialPageRoute(
+                  builder: (context) => FiatWithdrawalDetailScreen(
+                      withdrawal, widget.websocket)));
+          Navigator.pop(context);
+        },
+            error: (err) => alert(context, 'error',
+                'failed to create withdrawal (${BeError.msg(err)})'));
       }
     }
   }

--- a/lib/withdrawal.dart
+++ b/lib/withdrawal.dart
@@ -82,7 +82,9 @@ class _WithdrawalCheckScreenState extends State<WithdrawalCheckScreen> {
                         subtitle: Text(
                             '${assetFormatWithUnitToUser(widget.asset.symbol, widget.amount != null ? widget.amount! : _extractedAmount)}')),
                     ListTile(
-                        title: Text('Recipient'),
+                        title: widget.l2Network != null
+                            ? Text('Invoice')
+                            : Text('Recipient'),
                         subtitle: Text(shortenStr(widget.recipient)))
                   ]),
                   Column(
@@ -220,6 +222,7 @@ class _WithdrawalFormScreenState extends State<WithdrawalFormScreen> {
             _saveRecipient,
             _recipientDescriptionController.text,
             tfCode);
+        Navigator.pop(context);
         Navigator.pop(context);
         res.when(
             (withdrawal) => Navigator.push(
@@ -363,7 +366,7 @@ class _WithdrawalFormScreenState extends State<WithdrawalFormScreen> {
                         widget.asset.isCrypto && widget.l2Network != null,
                         BronzeFormInput(_recipientController,
                             icon: Icon(Icons.person_outlined),
-                            labelText: 'Recipient',
+                            labelText: 'Invoice',
                             suffixIcon: IconButton(
                                 onPressed: _scanRecipient,
                                 icon: Icon(Icons.qr_code)),


### PR DESCRIPTION
In reference to issue: https://github.com/zap-me/ops/issues/164

Changes:

- Remove 'sats' from BronzeValueInput widget LN withdrawals
- Pop withdrawal entry form once withdrawal complete for crypto withdrawals
- Pop deposit entry form once withdrawal complete for crypto deposits
- Change inconsistencies in invoice & recipient instances
- Add back button to Account2Account
- Add cancel button to 'choose your NZD deposit type' page

Will continue to test and update PR