### PR TITLE
fix websocket withdrawal updates

### DIFF
--- a/lib/websocket.dart
+++ b/lib/websocket.dart
@@ -123,9 +123,9 @@ class Websocket {
       call(WebsocketEvent.cryptoWithdrawalNew, data);
       log.info('crypto_withdrawal_new: $data');
     });
-    socket.on('crypto_deposit_update', (data) {
-      call(WebsocketEvent.cryptoDepositUpdate, data);
-      log.info('crypto_deposit_update: $data');
+    socket.on('crypto_withdrawal_update', (data) {
+      call(WebsocketEvent.cryptoWithdrawalUpdate, data);
+      log.info('crypto_withdrawal_update: $data');
     });
     socket.on('fiat_withdrawal_new', (data) {
       call(WebsocketEvent.fiatWithdrawalNew, data);

--- a/lib/withdrawal.dart
+++ b/lib/withdrawal.dart
@@ -610,6 +610,17 @@ class _CryptoWithdrawalsScreenState extends State<CryptoWithdrawalsScreen> {
         setState(() => _withdrawals = _withdrawals);
       }
     }
+    if (args.event == WebsocketEvent.cryptoWithdrawalUpdate) {
+      var newWithdrawal = BeCryptoWithdrawal.fromJson(jsonDecode(args.msg));
+      for (var i = 0; i < _withdrawals.length; i++) {
+        var withdrawal = _withdrawals[i];
+        if (withdrawal.token == newWithdrawal.token) {
+          _withdrawals[i] = newWithdrawal;
+          setState(() => _withdrawals = _withdrawals);
+          snackMsg(context, 'withdrawal updated ${newWithdrawal.token}');
+        }
+      }
+    }
   }
 
   Future<void> _initWithdrawals(int pageNumber) async {
@@ -840,6 +851,17 @@ class _FiatWithdrawalsScreenState extends State<FiatWithdrawalsScreen> {
         _withdrawals.insert(0, withdrawal);
         if (_withdrawals.length > _itemsPerPage) _withdrawals.removeLast();
         setState(() => _withdrawals = _withdrawals);
+      }
+    }
+    if (args.event == WebsocketEvent.fiatWithdrawalUpdate) {
+      var newWithdrawal = BeFiatWithdrawal.fromJson(jsonDecode(args.msg));
+      for (var i = 0; i < _withdrawals.length; i++) {
+        var withdrawal = _withdrawals[i];
+        if (withdrawal.token == newWithdrawal.token) {
+          _withdrawals[i] = newWithdrawal;
+          setState(() => _withdrawals = _withdrawals);
+          snackMsg(context, 'withdrawal updated ${newWithdrawal.token}');
+        }
       }
     }
   }


### PR DESCRIPTION
there was a typo in lib/websocket.dart which meant that we were not getting `crypto_withdrawal_update` events

also added withdrawal update handling on the 'list of withdrawals' page so they automatically update and you dont have to go out then back in again to get an update