### PR TITLE
bank account deposit fixes

### DIFF
--- a/lib/deposit.dart
+++ b/lib/deposit.dart
@@ -560,6 +560,7 @@ class _FiatDepositsScreenState extends State<FiatDepositsScreen> {
         ;
         break;
       case DepositMethod.bankDeposit:
+        showAlertDialog(context, 'querying..');
         var res = await beFiatDepositDirect(widget.asset.symbol);
         Navigator.pop(context);
         res.when(
@@ -676,7 +677,7 @@ class _FiatDepositDetailScreenState extends State<FiatDepositDetailScreen> {
               title: Text('Status'),
               subtitle: Text('${_deposit.status.toUpperCase()}')),
           VerticalSpacer(),
-          Row(mainAxisAlignment: MainAxisAlignment.center, children: <Widget>[
+          Row(mainAxisAlignment: MainAxisAlignment.center, children: [
             BronzeRoundedButton(() => Navigator.of(context).pop(), Colors.white,
                 Colors.white30, null, 'Close',
                 width: ButtonWidth, height: ButtonHeight)
@@ -727,38 +728,41 @@ class _FiatAccountNumberScreenState extends State<FiatAccountNumberScreen> {
           actions: [assetLogo(widget.asset.symbol, margin: EdgeInsets.all(10))],
         ),
         body: BiforgePage(
-            child: SizedBox(
-                width: ButtonWidth,
-                child: ListView(children: [
-                  Container(
-                      padding: EdgeInsets.only(top: 20, bottom: 20),
-                      child: Center(
-                          child: Icon(Icons.keyboard_double_arrow_down_rounded,
-                              size: 150, color: ZapOnSecondary))),
-                  ListTile(
-                      title: Text('Account Number'),
-                      subtitle: Text(widget.account.accountNumber),
-                      trailing: IconButton(
-                          onPressed: () => _copy(
-                              'account number', widget.account.accountNumber),
-                          icon: Icon(Icons.copy))),
-                  ListTile(
-                      title: Text('Reference'),
-                      subtitle: Text(widget.account.reference),
-                      trailing: IconButton(
-                          onPressed: () =>
-                              _copy('reference', widget.account.reference),
-                          icon: Icon(Icons.copy))),
-                  ListTile(
-                      title: Text('Code'),
-                      subtitle: Text(widget.account.code),
-                      trailing: IconButton(
-                          onPressed: () => _copy('code', widget.account.code),
-                          icon: Icon(Icons.copy))),
-                  VerticalSpacer(),
-                  BronzeRoundedButton(() => Navigator.of(context).pop(),
-                      Colors.white, Colors.white30, null, 'Cancel',
-                      width: ButtonWidth, height: ButtonHeight)
-                ]))));
+            child: ListView(children: [
+          Container(
+              padding: EdgeInsets.only(top: 20, bottom: 20),
+              child: Center(
+                  child: Icon(Icons.keyboard_double_arrow_down_rounded,
+                      size: 150, color: ZapOnSecondary))),
+          Padding(
+              padding: EdgeInsets.only(bottom: 20),
+              child: Text(
+                  'Make a deposit to our bank account. It is important to provide the exact reference and code details shown here.')),
+          ListTile(
+              title: Text('Bitforge Account Number'),
+              subtitle: Text(widget.account.accountNumber),
+              trailing: IconButton(
+                  onPressed: () =>
+                      _copy('account number', widget.account.accountNumber),
+                  icon: Icon(Icons.copy))),
+          ListTile(
+              title: Text('Reference'),
+              subtitle: Text(widget.account.reference),
+              trailing: IconButton(
+                  onPressed: () => _copy('reference', widget.account.reference),
+                  icon: Icon(Icons.copy))),
+          ListTile(
+              title: Text('Code'),
+              subtitle: Text(widget.account.code),
+              trailing: IconButton(
+                  onPressed: () => _copy('code', widget.account.code),
+                  icon: Icon(Icons.copy))),
+          VerticalSpacer(),
+          Row(mainAxisAlignment: MainAxisAlignment.center, children: [
+            BronzeRoundedButton(() => Navigator.of(context).pop(), Colors.white,
+                Colors.white30, null, 'Cancel',
+                width: ButtonWidth, height: ButtonHeight)
+          ])
+        ])));
   }
 }

--- a/lib/event.dart
+++ b/lib/event.dart
@@ -139,8 +139,8 @@ class _DepositAmountScreenState extends State<DepositAmountScreen> {
                           child: Container(
                               padding: EdgeInsets.only(
                                   left: 30, right: 30, top: 10, bottom: 10),
-                              // Fudge factor of 14.0 to match border radius of button
-                              width: ButtonWidth + 14.0,
+                              // Fudge factor of 54.0 to match border radius of button
+                              width: ButtonWidth + 54.0,
                               child: Column(children: [
                                 BronzeValueInput(
                                   controller: _amountController,


### PR DESCRIPTION
addresses https://github.com/zap-me/ops/issues/180
>need more info for the user (copy this bank account into your banking app..., here are our bank account details, make sure you enter all details..) #B
>something to make specific that these are our bank account details, and your specific deposit code #B


- fix input 'fudge factor' on deposit amount page to match input width to button width
- fix missing 'querying..' dialog before showing bank account details screen
- show info to make clear that bank account deposit screen refers to 'our' bank account
- fix width of fields on bank account deposit screen