### PR TITLE
remove dotted border from amount inputs

### DIFF
--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:dotted_border/dotted_border.dart';
 import 'package:universal_platform/universal_platform.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:universal_html/html.dart' as html;
@@ -208,7 +207,6 @@ class BronzeValueInput extends StatelessWidget {
   Widget build(BuildContext context) {
     return RoundedEdgeBox(
         borderColor: Colors.white,
-        dottedBorder: true,
         color: ZapSurface,
         child: TextFormField(
           controller: this.controller,
@@ -319,7 +317,6 @@ class RoundedEdgeBox extends StatelessWidget {
   final Gradient? gradient;
   final Color? color;
   final double borderRadius;
-  final bool dottedBorder;
   final double borderWidth;
   final Color? borderColor;
   final EdgeInsets padding;
@@ -329,35 +326,20 @@ class RoundedEdgeBox extends StatelessWidget {
       this.gradient,
       this.color,
       this.borderRadius = 10,
-      this.dottedBorder = false,
       this.borderWidth = 2,
       this.borderColor,
       this.padding = const EdgeInsets.all(8)});
 
-  Widget _dbox({bool drawBorder: false}) {
+  @override
+  Widget build(BuildContext context) {
     return DecoratedBox(
         decoration: BoxDecoration(
             gradient: gradient,
             color: color,
-            border: drawBorder
-                ? Border.all(
-                    color: borderColor ?? Colors.black, width: borderWidth)
-                : null,
+            border: Border.all(
+                color: borderColor ?? Colors.black, width: borderWidth),
             borderRadius: BorderRadius.circular(borderRadius)),
         child: Padding(padding: padding, child: child));
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    if (dottedBorder)
-      return DottedBorder(
-          padding: EdgeInsets.zero,
-          borderType: BorderType.RRect,
-          strokeWidth: borderWidth,
-          radius: Radius.circular(borderRadius),
-          color: borderColor ?? Colors.black,
-          child: _dbox(drawBorder: false));
-    return _dbox(drawBorder: true);
   }
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -288,13 +288,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.1"
-  dotted_border:
-    dependency: "direct main"
-    description:
-      name: dotted_border
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0+2"
   edit_distance:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,6 @@ dependencies:
   logging: ^1.0.2
   universal_html: ^2.0.8
   qr_flutter: ^4.0.0
-  dotted_border: ^2.0.0+2
   rxdart: ^0.27.4
   intl: ^0.17.0
   #mobile_scanner: ^1.0.0


### PR DESCRIPTION
Was getting annoyed that the dotted border actually makes the widget bigger and was trying to fix it then realized maybe it just looks better without a dotted border

![image](https://user-images.githubusercontent.com/42459/186065658-8e08b2b7-c098-409f-a81a-87266e84c779.png)
what do you think?