### PR TITLE
Fix Deposit Withdrawal Unscrollability

### DIFF
--- a/lib/deposit.dart
+++ b/lib/deposit.dart
@@ -153,10 +153,9 @@ class _DepositsScreenState extends State<DepositsScreen> {
                   ? Container(
                       margin: EdgeInsets.all(20),
                       child: Center(child: Text('No deposits')))
-                  : ListView.builder(
-                      shrinkWrap: true,
-                      itemBuilder: _listItem,
-                      itemCount: _deposits.length)
+                  : Expanded(
+                      child: ListView.builder(
+                          itemBuilder: _listItem, itemCount: _deposits.length))
             ])),
         bottomNavigationBar: _pageCount > 0
             ? Paginator(_pageCount, _pageNumber, (n) => _initDeposits(n))

--- a/lib/withdrawal.dart
+++ b/lib/withdrawal.dart
@@ -158,10 +158,9 @@ class _WithdrawalsScreenState extends State<WithdrawalsScreen> {
             ? Container(
                 margin: EdgeInsets.all(20),
                 child: Center(child: Text('No withdrawals')))
-            : ListView.builder(
-                shrinkWrap: true,
-                itemBuilder: _listItem,
-                itemCount: _withdrawals.length)
+            : Expanded(
+                child: ListView.builder(
+                    itemBuilder: _listItem, itemCount: _withdrawals.length))
       ])),
       bottomNavigationBar: _pageCount > 0
           ? Paginator(_pageCount, _pageNumber, (n) => _initWithdrawals(n))


### PR DESCRIPTION
# Fix Deposit Withdrawal Unscrollability

This is in reference to the first checkbox under 'Buggy' in https://github.com/zap-me/ops/issues/191.

It looks like the issue is with the ListView `shrinkWrap` property.

We don't have this error with the Order History page as the child widget of the `BiForgePage` class is the `ListView` widget, however in the Deposits and Withdrawals page, the `ListView` widget is a child of a `Column` widget which doesn't have explicit height or width properties.

Solely removing the `shrinkWrap` property in this case removes all deposits and withdrawal history, hence I wrapped it in an `Expanded` widget first which gives it a height, so I could remove the `shrinkWrap` property.

This stops the Widget Overflow error which existed before and allows scrollability for ListTiles which are off the screen, which didn't exist before.

There's probably a better way to do it so that the length of the ListView doesn't exceed the viewport height, but this is the best fix for now IMO.

## Before patch:

![IMG_7424](https://user-images.githubusercontent.com/72790952/187803309-0d02e80e-07a0-473f-bc36-96933d2d4a5b.gif)

## After patch:

![ezgif com-gif-maker](https://user-images.githubusercontent.com/72790952/187803584-268f8709-0ccb-486f-9cb9-43a681feb760.gif)




