### PR TITLE
Fix inconsistent Icon size in bottom nav bar

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -503,7 +503,8 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
           unselectedLabelStyle: TextStyle(fontSize: 12, color: Colors.blue),
           items: [
             BottomNavigationBarItem(
-                icon: _gradientIcon(Icons.history, text: 'Order History'),
+                icon: _gradientIcon(Icons.history,
+                    size: 28.0, text: 'Order History'),
                 label: 'Order History'),
             BottomNavigationBarItem(
                 icon: _gradientIcon(Icons.keyboard_double_arrow_down_rounded,


### PR DESCRIPTION
Looks like we missed adding `size:28.0` to the Order History button, which was causing inconsistent text alignment.

This is in reference to https://github.com/zap-me/ops/issues/191.