### PR TITLE
Stylize the AlertDialog widget we use to fit our Bitforge theme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -195,7 +195,7 @@ class _MyHomePageState extends State<MyHomePage>
         log.info(
             'old version ${cfg.AppVersion}, currently deployed version is $clientVersionDeployed');
         if (UniversalPlatform.isWeb) {
-          askYesNo(context,
+          bronzeAskYesNo(context,
                   'A newer version has been released would you like to reload?')
               .then((value) {
             if (value) html.window.location.reload();
@@ -261,7 +261,7 @@ class _MyHomePageState extends State<MyHomePage>
   }
 
   Future<void> _logout() async {
-    if (await askYesNo(context, 'Are you sure you want to logout?')) {
+    if (await bronzeAskYesNo(context, 'Are you sure you want to logout?')) {
       await Prefs.nukeAll();
       Phoenix.rebirth(context);
     }

--- a/lib/profile.dart
+++ b/lib/profile.dart
@@ -145,7 +145,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
   }
 
   Future<void> _resetPassword() async {
-    if (!await askYesNo(
+    if (!await bronzeAskYesNo(
         context, 'Are you sure you want to reset your password?')) return;
     showAlertDialog(context, 'requesting password reset..');
     var result = await beUserResetPassword();

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -558,3 +558,36 @@ class ListTx extends StatelessWidget {
     ]);
   }
 }
+
+Future<bool> bronzeAskYesNo(BuildContext context, String question) async {
+  var res = await showDialog<bool>(
+    context: context,
+    builder: (BuildContext context) {
+      return AlertDialog(
+        title: Text(question, textAlign: TextAlign.center),
+        contentPadding: EdgeInsets.only(bottom: 10.0),
+        shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(32.0))),
+        content: SizedBox(
+            height: cfg.ButtonHeight * 2.8,
+            width: cfg.ButtonWidth * 1.5,
+            child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: <Widget>[
+                  BronzeRoundedButton(() {
+                    Navigator.pop(context, true);
+                  }, ZapOnPrimary, ZapPrimary, ZapPrimaryGradient, 'Yes',
+                      fwdArrow: true,
+                      width: cfg.ButtonWidth,
+                      height: cfg.ButtonHeight),
+                  BronzeRoundedButton(() {
+                    Navigator.pop(context, false);
+                  }, ZapOnSurface, ZapSurface, null, 'No',
+                      width: cfg.ButtonWidth, height: cfg.ButtonHeight)
+                ])),
+      );
+    },
+  );
+  return res == true;
+}


### PR DESCRIPTION
I have made a class called `bronzeAskYesNo` which we can use as a replacement for the `zaplib` class function `askYesNo`.

Reasons for replacement:

- Styling matches our Bitforge app styling
- Buttons are larger, more easy to press